### PR TITLE
Fix compiling warnings.

### DIFF
--- a/include/guppirawc99/directio.h
+++ b/include/guppirawc99/directio.h
@@ -2,8 +2,7 @@
 #define GUPPI_RAW_C99_DIRECTIO_H_
 
 #ifndef _GNU_SOURCE
-#pragma message("_GNU_SOURCE not defined so DIRECTIO is disabled!") 
-#define O_DIRECT 0
+#define _GNU_SOURCE
 #endif
 
 #endif // GUPPI_RAW_C99_DIRECTIO_H_

--- a/src/guppiraw.c
+++ b/src/guppiraw.c
@@ -199,7 +199,7 @@ ssize_t guppiraw_write_block_batched(
   for(aspect_batch_i = 0; aspect_batch_i < n_aspect_batch; aspect_batch_i++) {
     for(batch_aspect_i = 0; batch_aspect_i < n_batched_aspect; batch_aspect_i++) {
       for(chan_batch_i = 0; chan_batch_i < n_chan_batch; chan_batch_i++) {
-        writev_params.iovecs[writev_params.iovec_count].iov_base = data + 
+        writev_params.iovecs[writev_params.iovec_count].iov_base = (void*)data + 
           aspect_batch_i*aspect_batch_block_size
           + chan_batch_i*batch_block_size
           + batch_aspect_i*batch_aspect_stride;
@@ -226,7 +226,7 @@ ssize_t guppiraw_write_block_batched(
       writev_params.iovecs[writev_params.iovec_count].iov_len += directio_pad_length;
     }
     else {
-        writev_params.iovecs[writev_params.iovec_count].iov_base = data;
+        writev_params.iovecs[writev_params.iovec_count].iov_base = (void*)data;
         writev_params.iovecs[writev_params.iovec_count].iov_len = directio_pad_length;
         writev_params.iovec_count++;
     }
@@ -265,7 +265,7 @@ ssize_t guppiraw_write_block_arbitrary(
       for(time_i = 0; time_i < datashape->n_time; time_i++){
         for(polarization_i = 0; polarization_i < datashape->n_pol; polarization_i++){
 
-          writev_params.iovecs[writev_params.iovec_count].iov_base = data
+          writev_params.iovecs[writev_params.iovec_count].iov_base = (void*)data
             + aspect_i * bytestride_aspect
             + time_i * bytestride_time
             + polarization_i * bytestride_polarization
@@ -295,7 +295,7 @@ ssize_t guppiraw_write_block_arbitrary(
       writev_params.iovecs[writev_params.iovec_count].iov_len += directio_pad_length;
     }
     else {
-        writev_params.iovecs[writev_params.iovec_count].iov_base = data;
+        writev_params.iovecs[writev_params.iovec_count].iov_base = (void*)data;
         writev_params.iovecs[writev_params.iovec_count].iov_len = directio_pad_length;
         writev_params.iovec_count++;
     }

--- a/src/iterate.c
+++ b/src/iterate.c
@@ -11,7 +11,7 @@ int _guppiraw_iterate_open(
   guppiraw_header_entry_parser user_callback
 ) {
   int rv = 0;
-  _file_info_ll_t *file_cur = NULL, *file_ll_head;
+  _file_info_ll_t *file_cur = NULL, *file_ll_head = NULL;
 
   char* filepath = malloc(gr_iterate->stempath_len+9+1);
   int fd;

--- a/tests/key_comparison.c
+++ b/tests/key_comparison.c
@@ -18,6 +18,7 @@ int main(){
   clock_t start, stop;
 
   int flag = -1;
+  (void)flag;
 
   start = clock();
   for(uint64_t i = 0; i < reiterations; i++) {


### PR DESCRIPTION
This PR solves some annoying compiling warnings. The last commit assumes that `_GNU_SOURCE` would be available in all deployed environments. Let me know if this is not the case.